### PR TITLE
Add missing packages

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER kakawait <thibaud.lepretre@gmail.com>
 ### Install dependencies ###
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
-  apt-get -yq install pwgen supervisor gettext-base && \
+  apt-get -yq install pwgen supervisor gettext-base sudo && \
   rm -rf /var/lib/apt/lists/*
 
 ### Install nuodb ###

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER kakawait <thibaud.lepretre@gmail.com>
 ### Install dependencies ###
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
-  apt-get -yq install pwgen supervisor && \
+  apt-get -yq install pwgen supervisor gettext-base && \
   rm -rf /var/lib/apt/lists/*
 
 ### Install nuodb ###


### PR DESCRIPTION
run.sh requires `envsubst` and `sudo` that are missing in the image.